### PR TITLE
Added the new automated test cases for Add Controls and Datasources to Entry Content on ContentTypes

### DIFF
--- a/src/test/java/org/craftercms/studio/test/api/SampleTest.java
+++ b/src/test/java/org/craftercms/studio/test/api/SampleTest.java
@@ -1,6 +1,6 @@
 package org.craftercms.studio.test.api;
 
-import org.craftercms.studio.test.utils.JsonTester;
+//import org.craftercms.studio.test.utils.JsonTester;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -13,10 +13,10 @@ import org.testng.annotations.Test;
 
 public class SampleTest {
 
-    private JsonTester api;
+    //private JsonTester api;
 
     public SampleTest(){
-        api = new JsonTester("http","localhost",8080);
+      //  api = new JsonTester("http","localhost",8080);
     }
 
     @BeforeTest

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddAutoFileNameTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddAutoFileNameTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
  * @author luishernandez
  *
  */
-public class ContentTypesAddVideoTest {
+public class ContentTypesAddAutoFileNameTest {
 	private WebDriverManager driverManager;
 	private LoginPage loginPage;
 	private HomePage homePage;
@@ -28,9 +28,9 @@ public class ContentTypesAddVideoTest {
 
 	private String controlsSectionFormSectionLocator;
 	private String contentTypeContainerLocator;
-	private String controlsSectionVideoLocator;
+	private String controlsSectionAutoFileNameLocator;
 	private String contentTypeContainerFormSectionContainerLocator;
-	private String contentTypeContainerVideoTitleLocator;
+	private String contentTypeContainerAutoFileNameTitleLocator;
 
 	@BeforeClass
 	public void beforeTest() {
@@ -44,12 +44,12 @@ public class ContentTypesAddVideoTest {
 				.getProperty("adminconsole.contenttype.entry.controlssectionformsection");
 		this.contentTypeContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainer");
-		this.controlsSectionVideoLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlsvideo");
+		this.controlsSectionAutoFileNameLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.controlsautofilename");
 		this.contentTypeContainerFormSectionContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainerformsectioncontainer");
-		this.contentTypeContainerVideoTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainervideotitle");
+		this.contentTypeContainerAutoFileNameTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerautofilenametitle");
 	
 	}
 
@@ -79,16 +79,16 @@ public class ContentTypesAddVideoTest {
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
 
-		WebElement FromVideo= driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionVideoLocator));
+		WebElement FromAutoFileName = driverManager.getDriver()
+				.findElement(By.xpath(controlsSectionAutoFileNameLocator));
 
 		WebElement ToDefaultSection = driverManager.getDriver()
 				.findElement(By.xpath(contentTypeContainerFormSectionContainerLocator));
 
-		siteConfigPage.getDriverManager().dragAndDropElement(FromVideo, ToDefaultSection);
+		siteConfigPage.getDriverManager().dragAndDropElement(FromAutoFileName, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefault");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddVideoTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddVideoTest() {
+	public void contentTypeAddAutoFileNameTest() {
 
 		// login to application
 
@@ -153,11 +153,11 @@ public class ContentTypesAddVideoTest {
 		driverManager.setImplicitlyWaitTimeForFindElements();
 		
 		// Click on input section to can view the properties
-		siteConfigPage.clickVideoSection();
+		siteConfigPage.clickAutoFileNameSection();
 
 		// Asserts that fields are not empty.
 		String titleText = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerVideoTitleLocator)).getText();
+				.findElement(By.xpath(contentTypeContainerAutoFileNameTitleLocator)).getText();
 
 		Assert.assertTrue(titleText.contains("TestTitle"));
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddCheckBoxTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddCheckBoxTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddCheckBoxTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForCheckBox() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddCheckBoxTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromCheckBox, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeaCheckBoxFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddCheckBoxTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddCheckBox() {
+	public void contentTypeAddCheckBoxTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddCheckBoxTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForCheckBox();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceChildContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceChildContentTest.java
@@ -1,36 +1,34 @@
-/**
- * 
- */
 package org.craftercms.studio.test.cases.contenttypepagetestcases;
 
-import org.craftercms.studio.test.pages.SiteConfigPage;
-import org.craftercms.studio.test.pages.HomePage;
-import org.craftercms.studio.test.pages.LoginPage;
-import org.craftercms.studio.test.utils.FilesLocations;
-import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
-import org.craftercms.studio.test.utils.WebDriverManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.craftercms.studio.test.pages.SiteConfigPage;
+import org.craftercms.studio.test.pages.HomePage;
+import org.craftercms.studio.test.pages.LoginPage;
+import org.craftercms.studio.test.utils.FilesLocations;
+import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
+import org.craftercms.studio.test.utils.WebDriverManager;
 
 /**
+ * 
  * @author luishernandez
  *
  */
-public class ContentTypesAddVideoTest {
+
+public class ContentTypesAddDataSourceChildContentTest {
+
 	private WebDriverManager driverManager;
 	private LoginPage loginPage;
 	private HomePage homePage;
 	private SiteConfigPage siteConfigPage;
-
-	private String controlsSectionFormSectionLocator;
+	
 	private String contentTypeContainerLocator;
-	private String controlsSectionVideoLocator;
-	private String contentTypeContainerFormSectionContainerLocator;
-	private String contentTypeContainerVideoTitleLocator;
+	private String dataSourceSectionChildContentLocator;
+	private String contentTypeContainerChildContentTitleLocator;
 
 	@BeforeClass
 	public void beforeTest() {
@@ -40,17 +38,12 @@ public class ContentTypesAddVideoTest {
 		this.loginPage = new LoginPage(driverManager, uIElementsPropertiesManager);
 		this.homePage = new HomePage(driverManager, uIElementsPropertiesManager);
 		this.siteConfigPage = new SiteConfigPage(driverManager, uIElementsPropertiesManager);
-		this.controlsSectionFormSectionLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlssectionformsection");
 		this.contentTypeContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainer");
-		this.controlsSectionVideoLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlsvideo");
-		this.contentTypeContainerFormSectionContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainerformsectioncontainer");
-		this.contentTypeContainerVideoTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainervideotitle");
-	
+		this.dataSourceSectionChildContentLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.datasourcechildcontent");
+		this.contentTypeContainerChildContentTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerchildcontenttitle");
 	}
 
 	@AfterTest
@@ -60,43 +53,31 @@ public class ContentTypesAddVideoTest {
 
 	public void dragAndDrop() {
 
-
 		driverManager.setImplicitlyWaitTimeForFindElements();
 
-		// Getting the Form Section control input for drag and drop action
-		WebElement FromControlSectionFormSectionElement = driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionFormSectionLocator));
+		// Getting the ChildContent for drag and drop action
+		WebElement FromDataSourceChildContentElement = driverManager.getDriver()
+				.findElement(By.xpath(dataSourceSectionChildContentLocator));
 
 		// Getting the Content Type Container for drag and drop action
 		// (destination)
 		WebElement ToContentTypeContainer = driverManager.getDriver()
 				.findElement(By.xpath(contentTypeContainerLocator));
 
-		driverManager.dragAndDropElement(FromControlSectionFormSectionElement, ToContentTypeContainer);
+		driverManager.dragAndDropElement(FromDataSourceChildContentElement, ToContentTypeContainer);
 		// wait for element
 
 		homePage.getDriverManager().driverWait();
 
-		driverManager.setImplicitlyWaitTimeForFindElements();
-
-		WebElement FromVideo= driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionVideoLocator));
-
-		WebElement ToDefaultSection = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerFormSectionContainerLocator));
-
-		siteConfigPage.getDriverManager().dragAndDropElement(FromVideo, ToDefaultSection);
-
 		// Complete the input fields basics
-		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeDataSourceFieldsBasics("TestTitle");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
-
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddVideoTest() {
+	public void contentTypeAddDataSourceChildContentTest() {
 
 		// login to application
 
@@ -153,13 +134,14 @@ public class ContentTypesAddVideoTest {
 		driverManager.setImplicitlyWaitTimeForFindElements();
 		
 		// Click on input section to can view the properties
-		siteConfigPage.clickVideoSection();
+		siteConfigPage.clickDataSourceChildContentSection();
 
 		// Asserts that fields are not empty.
 		String titleText = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerVideoTitleLocator)).getText();
+				.findElement(By.xpath(contentTypeContainerChildContentTitleLocator)).getText();
 
 		Assert.assertTrue(titleText.contains("TestTitle"));
 
 	}
+
 }

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceImageUploadedFromCMISRepositoryTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceImageUploadedFromCMISRepositoryTest.java
@@ -1,36 +1,34 @@
-/**
- * 
- */
 package org.craftercms.studio.test.cases.contenttypepagetestcases;
 
-import org.craftercms.studio.test.pages.SiteConfigPage;
-import org.craftercms.studio.test.pages.HomePage;
-import org.craftercms.studio.test.pages.LoginPage;
-import org.craftercms.studio.test.utils.FilesLocations;
-import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
-import org.craftercms.studio.test.utils.WebDriverManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.craftercms.studio.test.pages.SiteConfigPage;
+import org.craftercms.studio.test.pages.HomePage;
+import org.craftercms.studio.test.pages.LoginPage;
+import org.craftercms.studio.test.utils.FilesLocations;
+import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
+import org.craftercms.studio.test.utils.WebDriverManager;
 
 /**
+ * 
  * @author luishernandez
  *
  */
-public class ContentTypesAddVideoTest {
+
+public class ContentTypesAddDataSourceImageUploadedFromCMISRepositoryTest {
+
 	private WebDriverManager driverManager;
 	private LoginPage loginPage;
 	private HomePage homePage;
 	private SiteConfigPage siteConfigPage;
-
-	private String controlsSectionFormSectionLocator;
+	
 	private String contentTypeContainerLocator;
-	private String controlsSectionVideoLocator;
-	private String contentTypeContainerFormSectionContainerLocator;
-	private String contentTypeContainerVideoTitleLocator;
+	private String dataSourceSectionImageUploadedFromCMISRepositoryLocator;
+	private String contentTypeContainerImageUploadedFromCMISRepositoryTitleLocator;
 
 	@BeforeClass
 	public void beforeTest() {
@@ -40,17 +38,12 @@ public class ContentTypesAddVideoTest {
 		this.loginPage = new LoginPage(driverManager, uIElementsPropertiesManager);
 		this.homePage = new HomePage(driverManager, uIElementsPropertiesManager);
 		this.siteConfigPage = new SiteConfigPage(driverManager, uIElementsPropertiesManager);
-		this.controlsSectionFormSectionLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlssectionformsection");
 		this.contentTypeContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainer");
-		this.controlsSectionVideoLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlsvideo");
-		this.contentTypeContainerFormSectionContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainerformsectioncontainer");
-		this.contentTypeContainerVideoTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainervideotitle");
-	
+		this.dataSourceSectionImageUploadedFromCMISRepositoryLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.datasourceimageuploadedfromCMISrepository");
+		this.contentTypeContainerImageUploadedFromCMISRepositoryTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerimageuploadedfromCMISrepositorytitle");
 	}
 
 	@AfterTest
@@ -60,43 +53,31 @@ public class ContentTypesAddVideoTest {
 
 	public void dragAndDrop() {
 
-
 		driverManager.setImplicitlyWaitTimeForFindElements();
 
-		// Getting the Form Section control input for drag and drop action
-		WebElement FromControlSectionFormSectionElement = driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionFormSectionLocator));
+		// Getting the ChildContent for drag and drop action
+		WebElement FromDataSourceImageUploadedFromRepoElement = driverManager.getDriver()
+				.findElement(By.xpath(dataSourceSectionImageUploadedFromCMISRepositoryLocator));
 
 		// Getting the Content Type Container for drag and drop action
 		// (destination)
 		WebElement ToContentTypeContainer = driverManager.getDriver()
 				.findElement(By.xpath(contentTypeContainerLocator));
 
-		driverManager.dragAndDropElement(FromControlSectionFormSectionElement, ToContentTypeContainer);
+		driverManager.dragAndDropElement(FromDataSourceImageUploadedFromRepoElement, ToContentTypeContainer);
 		// wait for element
 
 		homePage.getDriverManager().driverWait();
 
-		driverManager.setImplicitlyWaitTimeForFindElements();
-
-		WebElement FromVideo= driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionVideoLocator));
-
-		WebElement ToDefaultSection = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerFormSectionContainerLocator));
-
-		siteConfigPage.getDriverManager().dragAndDropElement(FromVideo, ToDefaultSection);
-
 		// Complete the input fields basics
-		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeDataSourceFieldsBasics("TestTitle");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
-
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddVideoTest() {
+	public void contentTypeAddDataSourceImageUploadedFromCMISRepositoryTest() {
 
 		// login to application
 
@@ -153,13 +134,14 @@ public class ContentTypesAddVideoTest {
 		driverManager.setImplicitlyWaitTimeForFindElements();
 		
 		// Click on input section to can view the properties
-		siteConfigPage.clickVideoSection();
+		siteConfigPage.clickDataSourceImageUploadedFromCMISRepositorySection();
 
 		// Asserts that fields are not empty.
 		String titleText = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerVideoTitleLocator)).getText();
+				.findElement(By.xpath(contentTypeContainerImageUploadedFromCMISRepositoryTitleLocator)).getText();
 
 		Assert.assertTrue(titleText.contains("TestTitle"));
 
 	}
+
 }

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceImageUploadedFromDesktopTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceImageUploadedFromDesktopTest.java
@@ -1,36 +1,34 @@
-/**
- * 
- */
 package org.craftercms.studio.test.cases.contenttypepagetestcases;
 
-import org.craftercms.studio.test.pages.SiteConfigPage;
-import org.craftercms.studio.test.pages.HomePage;
-import org.craftercms.studio.test.pages.LoginPage;
-import org.craftercms.studio.test.utils.FilesLocations;
-import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
-import org.craftercms.studio.test.utils.WebDriverManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.craftercms.studio.test.pages.SiteConfigPage;
+import org.craftercms.studio.test.pages.HomePage;
+import org.craftercms.studio.test.pages.LoginPage;
+import org.craftercms.studio.test.utils.FilesLocations;
+import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
+import org.craftercms.studio.test.utils.WebDriverManager;
 
 /**
+ * 
  * @author luishernandez
  *
  */
-public class ContentTypesAddVideoTest {
+
+public class ContentTypesAddDataSourceImageUploadedFromDesktopTest {
+
 	private WebDriverManager driverManager;
 	private LoginPage loginPage;
 	private HomePage homePage;
 	private SiteConfigPage siteConfigPage;
-
-	private String controlsSectionFormSectionLocator;
+	
 	private String contentTypeContainerLocator;
-	private String controlsSectionVideoLocator;
-	private String contentTypeContainerFormSectionContainerLocator;
-	private String contentTypeContainerVideoTitleLocator;
+	private String dataSourceSectionImageUploadedFromDesktopLocator;
+	private String contentTypeContainerImageUploadedFromDesktopTitleLocator;
 
 	@BeforeClass
 	public void beforeTest() {
@@ -40,17 +38,12 @@ public class ContentTypesAddVideoTest {
 		this.loginPage = new LoginPage(driverManager, uIElementsPropertiesManager);
 		this.homePage = new HomePage(driverManager, uIElementsPropertiesManager);
 		this.siteConfigPage = new SiteConfigPage(driverManager, uIElementsPropertiesManager);
-		this.controlsSectionFormSectionLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlssectionformsection");
 		this.contentTypeContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainer");
-		this.controlsSectionVideoLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlsvideo");
-		this.contentTypeContainerFormSectionContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainerformsectioncontainer");
-		this.contentTypeContainerVideoTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainervideotitle");
-	
+		this.dataSourceSectionImageUploadedFromDesktopLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.datasourceimageuploadedfromdesktop");
+		this.contentTypeContainerImageUploadedFromDesktopTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerimageuploadedfromdesktoptitle");
 	}
 
 	@AfterTest
@@ -60,43 +53,31 @@ public class ContentTypesAddVideoTest {
 
 	public void dragAndDrop() {
 
-
 		driverManager.setImplicitlyWaitTimeForFindElements();
 
-		// Getting the Form Section control input for drag and drop action
-		WebElement FromControlSectionFormSectionElement = driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionFormSectionLocator));
+		// Getting the ChildContent for drag and drop action
+		WebElement FromDataSourceImageUploadedFromDesktopElement = driverManager.getDriver()
+				.findElement(By.xpath(dataSourceSectionImageUploadedFromDesktopLocator));
 
 		// Getting the Content Type Container for drag and drop action
 		// (destination)
 		WebElement ToContentTypeContainer = driverManager.getDriver()
 				.findElement(By.xpath(contentTypeContainerLocator));
 
-		driverManager.dragAndDropElement(FromControlSectionFormSectionElement, ToContentTypeContainer);
+		driverManager.dragAndDropElement(FromDataSourceImageUploadedFromDesktopElement, ToContentTypeContainer);
 		// wait for element
 
 		homePage.getDriverManager().driverWait();
 
-		driverManager.setImplicitlyWaitTimeForFindElements();
-
-		WebElement FromVideo= driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionVideoLocator));
-
-		WebElement ToDefaultSection = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerFormSectionContainerLocator));
-
-		siteConfigPage.getDriverManager().dragAndDropElement(FromVideo, ToDefaultSection);
-
 		// Complete the input fields basics
-		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeDataSourceFieldsBasics("TestTitle");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
-
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddVideoTest() {
+	public void contentTypeAddDataSourceImageUploadedFromDesktopTest() {
 
 		// login to application
 
@@ -153,13 +134,14 @@ public class ContentTypesAddVideoTest {
 		driverManager.setImplicitlyWaitTimeForFindElements();
 		
 		// Click on input section to can view the properties
-		siteConfigPage.clickVideoSection();
+		siteConfigPage.clickDataSourceImageUploadedFromDesktopSection();
 
 		// Asserts that fields are not empty.
 		String titleText = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerVideoTitleLocator)).getText();
+				.findElement(By.xpath(contentTypeContainerImageUploadedFromDesktopTitleLocator)).getText();
 
 		Assert.assertTrue(titleText.contains("TestTitle"));
 
 	}
+
 }

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceImageUploadedFromRepositoryTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDataSourceImageUploadedFromRepositoryTest.java
@@ -1,36 +1,34 @@
-/**
- * 
- */
 package org.craftercms.studio.test.cases.contenttypepagetestcases;
 
-import org.craftercms.studio.test.pages.SiteConfigPage;
-import org.craftercms.studio.test.pages.HomePage;
-import org.craftercms.studio.test.pages.LoginPage;
-import org.craftercms.studio.test.utils.FilesLocations;
-import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
-import org.craftercms.studio.test.utils.WebDriverManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.craftercms.studio.test.pages.SiteConfigPage;
+import org.craftercms.studio.test.pages.HomePage;
+import org.craftercms.studio.test.pages.LoginPage;
+import org.craftercms.studio.test.utils.FilesLocations;
+import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
+import org.craftercms.studio.test.utils.WebDriverManager;
 
 /**
+ * 
  * @author luishernandez
  *
  */
-public class ContentTypesAddVideoTest {
+
+public class ContentTypesAddDataSourceImageUploadedFromRepositoryTest {
+
 	private WebDriverManager driverManager;
 	private LoginPage loginPage;
 	private HomePage homePage;
 	private SiteConfigPage siteConfigPage;
-
-	private String controlsSectionFormSectionLocator;
+	
 	private String contentTypeContainerLocator;
-	private String controlsSectionVideoLocator;
-	private String contentTypeContainerFormSectionContainerLocator;
-	private String contentTypeContainerVideoTitleLocator;
+	private String dataSourceSectionImageUploadedFromRepositoryLocator;
+	private String contentTypeContainerImageUploadedFromRepositoryTitleLocator;
 
 	@BeforeClass
 	public void beforeTest() {
@@ -40,17 +38,12 @@ public class ContentTypesAddVideoTest {
 		this.loginPage = new LoginPage(driverManager, uIElementsPropertiesManager);
 		this.homePage = new HomePage(driverManager, uIElementsPropertiesManager);
 		this.siteConfigPage = new SiteConfigPage(driverManager, uIElementsPropertiesManager);
-		this.controlsSectionFormSectionLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlssectionformsection");
 		this.contentTypeContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainer");
-		this.controlsSectionVideoLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlsvideo");
-		this.contentTypeContainerFormSectionContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainerformsectioncontainer");
-		this.contentTypeContainerVideoTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainervideotitle");
-	
+		this.dataSourceSectionImageUploadedFromRepositoryLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.datasourceimageuploadedfromrepository");
+		this.contentTypeContainerImageUploadedFromRepositoryTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerimageuploadedfromrepositorytitle");
 	}
 
 	@AfterTest
@@ -60,43 +53,31 @@ public class ContentTypesAddVideoTest {
 
 	public void dragAndDrop() {
 
-
 		driverManager.setImplicitlyWaitTimeForFindElements();
 
-		// Getting the Form Section control input for drag and drop action
-		WebElement FromControlSectionFormSectionElement = driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionFormSectionLocator));
+		// Getting the ChildContent for drag and drop action
+		WebElement FromDataSourceImageUploadedFromRepoElement = driverManager.getDriver()
+				.findElement(By.xpath(dataSourceSectionImageUploadedFromRepositoryLocator));
 
 		// Getting the Content Type Container for drag and drop action
 		// (destination)
 		WebElement ToContentTypeContainer = driverManager.getDriver()
 				.findElement(By.xpath(contentTypeContainerLocator));
 
-		driverManager.dragAndDropElement(FromControlSectionFormSectionElement, ToContentTypeContainer);
+		driverManager.dragAndDropElement(FromDataSourceImageUploadedFromRepoElement, ToContentTypeContainer);
 		// wait for element
 
 		homePage.getDriverManager().driverWait();
 
-		driverManager.setImplicitlyWaitTimeForFindElements();
-
-		WebElement FromVideo= driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionVideoLocator));
-
-		WebElement ToDefaultSection = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerFormSectionContainerLocator));
-
-		siteConfigPage.getDriverManager().dragAndDropElement(FromVideo, ToDefaultSection);
-
 		// Complete the input fields basics
-		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeDataSourceFieldsBasics("TestTitle");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
-
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddVideoTest() {
+	public void contentTypeAddDataSourceImageUploadedFromRepositoryTest() {
 
 		// login to application
 
@@ -153,13 +134,14 @@ public class ContentTypesAddVideoTest {
 		driverManager.setImplicitlyWaitTimeForFindElements();
 		
 		// Click on input section to can view the properties
-		siteConfigPage.clickVideoSection();
+		siteConfigPage.clickDataSourceImageUploadedFromRepositorySection();
 
 		// Asserts that fields are not empty.
 		String titleText = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerVideoTitleLocator)).getText();
+				.findElement(By.xpath(contentTypeContainerImageUploadedFromRepositoryTitleLocator)).getText();
 
 		Assert.assertTrue(titleText.contains("TestTitle"));
 
 	}
+
 }

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDateTimeTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDateTimeTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddDateTimeTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForDateTime() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddDateTimeTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromDateTime, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeaDateTimeFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddDateTimeTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddDateTime() {
+	public void contentTypeAddDateTimeTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddDateTimeTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForDateTime();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDropdownTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddDropdownTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddDropdownTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForDropDown() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddDropdownTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromDropDown, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeDropdonwFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddDropdownTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddDropdown() {
+	public void contentTypeAddDropdownTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddDropdownTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForDropDown();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddFileNameTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddFileNameTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
  * @author luishernandez
  *
  */
-public class ContentTypesAddVideoTest {
+public class ContentTypesAddFileNameTest {
 	private WebDriverManager driverManager;
 	private LoginPage loginPage;
 	private HomePage homePage;
@@ -28,9 +28,9 @@ public class ContentTypesAddVideoTest {
 
 	private String controlsSectionFormSectionLocator;
 	private String contentTypeContainerLocator;
-	private String controlsSectionVideoLocator;
+	private String controlsSectionFileNameLocator;
 	private String contentTypeContainerFormSectionContainerLocator;
-	private String contentTypeContainerVideoTitleLocator;
+	private String contentTypeContainerFileNameTitleLocator;
 
 	@BeforeClass
 	public void beforeTest() {
@@ -44,12 +44,12 @@ public class ContentTypesAddVideoTest {
 				.getProperty("adminconsole.contenttype.entry.controlssectionformsection");
 		this.contentTypeContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainer");
-		this.controlsSectionVideoLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.controlsvideo");
+		this.controlsSectionFileNameLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.controlsfilename");
 		this.contentTypeContainerFormSectionContainerLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainerformsectioncontainer");
-		this.contentTypeContainerVideoTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("adminconsole.contenttype.entry.contenttypecontainervideotitle");
+		this.contentTypeContainerFileNameTitleLocator = uIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerfilenametitle");
 	
 	}
 
@@ -79,16 +79,16 @@ public class ContentTypesAddVideoTest {
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
 
-		WebElement FromVideo= driverManager.getDriver()
-				.findElement(By.xpath(controlsSectionVideoLocator));
+		WebElement FromFileName = driverManager.getDriver()
+				.findElement(By.xpath(controlsSectionFileNameLocator));
 
 		WebElement ToDefaultSection = driverManager.getDriver()
 				.findElement(By.xpath(contentTypeContainerFormSectionContainerLocator));
 
-		siteConfigPage.getDriverManager().dragAndDropElement(FromVideo, ToDefaultSection);
+		siteConfigPage.getDriverManager().dragAndDropElement(FromFileName, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefault");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddVideoTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddVideoTest() {
+	public void contentTypeAddFileNameTest() {
 
 		// login to application
 
@@ -153,11 +153,11 @@ public class ContentTypesAddVideoTest {
 		driverManager.setImplicitlyWaitTimeForFindElements();
 		
 		// Click on input section to can view the properties
-		siteConfigPage.clickVideoSection();
+		siteConfigPage.clickFileNameSection();
 
 		// Asserts that fields are not empty.
 		String titleText = driverManager.getDriver()
-				.findElement(By.xpath(contentTypeContainerVideoTitleLocator)).getText();
+				.findElement(By.xpath(contentTypeContainerFileNameTitleLocator)).getText();
 
 		Assert.assertTrue(titleText.contains("TestTitle"));
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddGroupedCheckBoxesTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddGroupedCheckBoxesTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddGroupedCheckBoxesTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForGroupedCheckBoxes() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddGroupedCheckBoxesTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromGroupedCheckBoxes, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeaGroupedCheckBoxesFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddGroupedCheckBoxesTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddGroupedCheckBoxes() {
+	public void contentTypeAddGroupedCheckBoxesTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddGroupedCheckBoxesTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForGroupedCheckBoxes();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddImageTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddImageTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddImageTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForImage() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddImageTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromImage, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeImageFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddImageTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddImage() {
+	public void contentTypeAddImageTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddImageTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForImage();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddInputTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddInputTest.java
@@ -57,7 +57,7 @@ public class ContentTypesAddInputTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForInput() {
+	public void dragAndDrop() {
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
 
@@ -86,14 +86,14 @@ public class ContentTypesAddInputTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromRepeatingGroup, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeInputFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefault");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefault");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
 	}
 
 	@Test(priority = 0)
-	public void contentTypeInputData() {
+	public void contentTypeAddInputTest() {
 
 		// login to application
 
@@ -129,7 +129,7 @@ public class ContentTypesAddInputTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForInput();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddItemSelectorTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddItemSelectorTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddItemSelectorTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForItemSelector() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddItemSelectorTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromItemSelector, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeItemSelectorFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddItemSelectorTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddItemSelector() {
+	public void contentTypeAddItemSelectorTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddItemSelectorTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForItemSelector();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddLabelTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddLabelTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddLabelTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForLabel() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddLabelTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromLabel, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeLabelFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddLabelTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddLabel() {
+	public void contentTypeAddLabelTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddLabelTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForLabel();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddPageOrderTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddPageOrderTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddPageOrderTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForPageOrder() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddPageOrderTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromLabel, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completePageOrderFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddPageOrderTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddLabel() {
+	public void contentTypeAddPageOrderTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddPageOrderTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForPageOrder();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddRepeatingGroupTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddRepeatingGroupTest.java
@@ -57,7 +57,7 @@ public class ContentTypesAddRepeatingGroupTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForRepeatingGroup() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -87,7 +87,7 @@ public class ContentTypesAddRepeatingGroupTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromRepeatingGroup, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeRepeatingGroupFieldsBasics("TestTitle", "TestICEGroup", "TestDescription");
+		siteConfigPage.completeControlFieldsBasics2("TestTitle", "TestICEGroup", "TestDescription");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -95,7 +95,7 @@ public class ContentTypesAddRepeatingGroupTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddRepeatingGroup() {
+	public void contentTypeAddRepeatingGroupTest() {
 
 		// login to application
 
@@ -131,7 +131,7 @@ public class ContentTypesAddRepeatingGroupTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForRepeatingGroup();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddRichTextEditorTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddRichTextEditorTest.java
@@ -58,7 +58,7 @@ public class ContentTypesAddRichTextEditorTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForRTE() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -88,7 +88,7 @@ public class ContentTypesAddRichTextEditorTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromRTE, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeRTEFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -96,7 +96,7 @@ public class ContentTypesAddRichTextEditorTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddRichTextEditor() {
+	public void contentTypeAddRichTextEditorTest() {
 
 		// login to application
 
@@ -132,7 +132,7 @@ public class ContentTypesAddRichTextEditorTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForRTE();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddTextAreaTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesAddTextAreaTest.java
@@ -57,7 +57,7 @@ public class ContentTypesAddTextAreaTest {
 		driverManager.closeConnection();
 	}
 
-	public void dragAndDropForTextArea() {
+	public void dragAndDrop() {
 
 
 		driverManager.setImplicitlyWaitTimeForFindElements();
@@ -87,7 +87,7 @@ public class ContentTypesAddTextAreaTest {
 		siteConfigPage.getDriverManager().dragAndDropElement(FromRepeatingGroup, ToDefaultSection);
 
 		// Complete the input fields basics
-		siteConfigPage.completeTextAreaFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaul");
 
 		// Save the data
 		siteConfigPage.saveDragAndDropProcess();
@@ -95,7 +95,7 @@ public class ContentTypesAddTextAreaTest {
 	}
 
 	@Test(priority = 0)
-	public void contentTypeAddTextArea() {
+	public void contentTypeAddTextAreaTest() {
 
 		// login to application
 
@@ -131,7 +131,7 @@ public class ContentTypesAddTextAreaTest {
 		siteConfigPage.getDriverManager().driverWait();
 
 		// drag and drop
-		this.dragAndDropForTextArea();
+		this.dragAndDrop();
 
 		// open content types
 		siteConfigPage.clickExistingTypeOption();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesDragAndDropTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttypepagetestcases/ContentTypesDragAndDropTest.java
@@ -59,7 +59,7 @@ public class ContentTypesDragAndDropTest {
 	}
 
 	@Test(priority = 0)
-	public void CT_Drap_And_Drop() {
+	public void contentTypesDragAndDropTest() {
 
 		// login to application
 

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationbartestcases/PublishingSiteTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationbartestcases/PublishingSiteTest.java
@@ -5,7 +5,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.craftercms.studio.test.pages.SiteConfigPage;
 import org.craftercms.studio.test.pages.DashboardPage;
 import org.craftercms.studio.test.pages.HomePage;
 import org.craftercms.studio.test.pages.LoginPage;
@@ -30,8 +29,6 @@ public class PublishingSiteTest {
 
 	private PreviewPage previewPage;
 
-	private SiteConfigPage siteConfigPage;
-
 	private DashboardPage dashboardPage;
 
 	@BeforeClass
@@ -42,7 +39,6 @@ public class PublishingSiteTest {
 		this.loginPage = new LoginPage(driverManager, uIElementsPropertiesManager);
 		this.homePage = new HomePage(driverManager, uIElementsPropertiesManager);
 		this.previewPage = new PreviewPage(driverManager, uIElementsPropertiesManager);
-		this.siteConfigPage = new SiteConfigPage(driverManager, uIElementsPropertiesManager);
 		this.dashboardPage = new DashboardPage(driverManager, uIElementsPropertiesManager);
 
 	}
@@ -52,59 +48,9 @@ public class PublishingSiteTest {
 		driverManager.closeConnection();
 	}
 
-	public void bodyNotRequiered() {
+	public void changeBodyToNotRequiredOnEntryContent() {
 
-		// go to admin console page
-
-		driverManager.getDriver().findElement(By.cssSelector("#admin-console")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// select content types
-		siteConfigPage.selectContentTypeOption();
-
-		// open content types
-
-		siteConfigPage.clickExistingTypeOption();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// Select the Entry content type
-
-		siteConfigPage.selectEntryContentType();
-
-		// Confirm the content type selected
-
-		siteConfigPage.confirmContentTypeSelected();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// select main content
-
-		driverManager.getDriver().findElement(By.cssSelector("#yui-gen8")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// Body not required
-
-		driverManager.getDriver()
-				.findElement(By.cssSelector("div.property-wrapper:nth-child(21) > div:nth-child(2) > input")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// save
-
-		siteConfigPage.saveDragAndDropProcess();
+		previewPage.changeBodyOfEntryContentPageToNotRequired();
 	}
 
 	public void createContent() {
@@ -262,7 +208,7 @@ public class PublishingSiteTest {
 
 		// body not requiered
 
-		bodyNotRequiered();
+		changeBodyToNotRequiredOnEntryContent();
 
 		// wait for element is clickeable
 

--- a/src/test/java/org/craftercms/studio/test/cases/dashboardpagetestcases/EditContentFormTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/dashboardpagetestcases/EditContentFormTest.java
@@ -146,7 +146,7 @@ public class EditContentFormTest {
 
 		// Complete the input fields basics
 
-		siteConfigPage.completeInputFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaultValue");
+		siteConfigPage.completeControlFieldsBasics("TestTitle", "TestICEGroup", "TestDescription", "TestDefaultValue");
 
 		// Save the data
 

--- a/src/test/java/org/craftercms/studio/test/cases/previewtoolstestcases/PresetEachDesignTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/previewtoolstestcases/PresetEachDesignTest.java
@@ -5,10 +5,10 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-import org.craftercms.studio.test.pages.SiteConfigPage;
 import org.craftercms.studio.test.pages.DashboardPage;
 import org.craftercms.studio.test.pages.HomePage;
 import org.craftercms.studio.test.pages.LoginPage;
+import org.craftercms.studio.test.pages.PreviewPage;
 import org.craftercms.studio.test.utils.FilesLocations;
 import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
 import org.craftercms.studio.test.utils.WebDriverManager;
@@ -29,7 +29,7 @@ public class PresetEachDesignTest {
 
 	private DashboardPage dashboardPage;
 
-	private SiteConfigPage siteConfigPage;
+	private PreviewPage previewPage;
 
 	@BeforeTest
 	public void beforeTest() {
@@ -39,7 +39,7 @@ public class PresetEachDesignTest {
 		this.loginPage = new LoginPage(driverManager, uIElementsPropertiesManager);
 		this.homePage = new HomePage(driverManager, uIElementsPropertiesManager);
 		this.dashboardPage = new DashboardPage(driverManager, uIElementsPropertiesManager);
-		this.siteConfigPage = new SiteConfigPage(driverManager, uIElementsPropertiesManager);
+		this.previewPage = new PreviewPage(driverManager, uIElementsPropertiesManager);
 
 	}
 
@@ -48,74 +48,9 @@ public class PresetEachDesignTest {
 		driverManager.closeConnection();
 	}
 
-	public void notRequired() {
-		// Show site content panel
-		driverManager.getDriver().findElement(By.xpath("/html/body/div[2]/div[1]/nav/div/div[2]/ul[1]/li/div/div[1]/a"))
-				.click();
+	public void changeBodyToNotRequiredOnEntryContent() {
 
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// go to admin console page
-
-		driverManager.getDriver().findElement(By.cssSelector("#admin-console")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// select content types
-		siteConfigPage.selectContentTypeOption();
-
-		// open content types
-
-		siteConfigPage.clickExistingTypeOption();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// Select the Entry content type
-
-		siteConfigPage.selectEntryContentType();
-
-		// Confirm the content type selected
-
-		siteConfigPage.confirmContentTypeSelected();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// select main content
-
-		driverManager.getDriver().findElement(By.cssSelector("#yui-gen8")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// Body not required
-
-		driverManager.getDriver()
-				.findElement(By.cssSelector("div.property-wrapper:nth-child(21) > div:nth-child(2) > input")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// save
-
-		siteConfigPage.saveDragAndDropProcess();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// go to dashboard
-
-		driverManager.getDriver().findElement(By.cssSelector("#cstudio-logo")).click();
+		previewPage.changeBodyOfEntryContentPageToNotRequired();
 
 	}
 
@@ -232,7 +167,7 @@ public class PresetEachDesignTest {
 
 		// body not required
 
-		notRequired();
+		changeBodyToNotRequiredOnEntryContent();
 
 		// wait for element is clickeable
 

--- a/src/test/java/org/craftercms/studio/test/cases/sitecontentbartestcases/AddNewContentEntryTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitecontentbartestcases/AddNewContentEntryTest.java
@@ -48,7 +48,7 @@ public class AddNewContentEntryTest {
 		driverManager.closeConnection();
 	}
 
-	public void notRequired() {
+	public void changeBodyToNotRequiredOnEntryContent() {
 
 		previewPage.changeBodyOfEntryContentPageToNotRequired();
 
@@ -154,7 +154,7 @@ public class AddNewContentEntryTest {
 		driverManager.getDriver().navigate().refresh();
 
 		// body not required
-		this.notRequired();
+		this.changeBodyToNotRequiredOnEntryContent();
 		// wait for element is clickeable
 
 		homePage.getDriverManager().driverWait();

--- a/src/test/java/org/craftercms/studio/test/cases/sitecontentbartestcases/DuplicateOptionTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitecontentbartestcases/DuplicateOptionTest.java
@@ -5,10 +5,10 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.craftercms.studio.test.pages.SiteConfigPage;
 import org.craftercms.studio.test.pages.DashboardPage;
 import org.craftercms.studio.test.pages.HomePage;
 import org.craftercms.studio.test.pages.LoginPage;
+import org.craftercms.studio.test.pages.PreviewPage;
 import org.craftercms.studio.test.utils.FilesLocations;
 import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
 import org.craftercms.studio.test.utils.WebDriverManager;
@@ -27,9 +27,9 @@ public class DuplicateOptionTest {
 
 	private HomePage homePage;
 
-	private SiteConfigPage siteConfigPage;
-
 	private DashboardPage dashboardPage;
+
+	private PreviewPage previewPage;
 
 	@BeforeClass
 	public void beforeTest() {
@@ -38,7 +38,7 @@ public class DuplicateOptionTest {
 				FilesLocations.UIELEMENTSPROPERTIESFILEPATH);
 		this.loginPage = new LoginPage(driverManager, uIElementsPropertiesManager);
 		this.homePage = new HomePage(driverManager, uIElementsPropertiesManager);
-		this.siteConfigPage = new SiteConfigPage(driverManager, uIElementsPropertiesManager);
+		this.previewPage = new PreviewPage(driverManager, uIElementsPropertiesManager);
 		this.dashboardPage = new DashboardPage(driverManager, uIElementsPropertiesManager);
 
 	}
@@ -48,58 +48,64 @@ public class DuplicateOptionTest {
 		driverManager.closeConnection();
 	}
 
-	public void selectContentTypeToTheTest() {
-		// go to admin console page
+//	public void selectContentTypeToTheTest() {
+//		// go to admin console page
+//
+//		driverManager.getDriver().findElement(By.cssSelector("#admin-console")).click();
+//
+//		// wait for element is clickeable
+//
+//		homePage.getDriverManager().driverWait();
+//
+//		// select content types
+//		siteConfigPage.selectContentTypeOption();
+//
+//		// open content types
+//
+//		siteConfigPage.clickExistingTypeOption();
+//
+//		// wait for element is clickeable
+//
+//		homePage.getDriverManager().driverWait();
+//
+//		// Select the Entry content type
+//
+//		siteConfigPage.selectEntryContentType();
+//
+//		// Confirm the content type selected
+//
+//		siteConfigPage.confirmContentTypeSelected();
+//
+//	}
 
-		driverManager.getDriver().findElement(By.cssSelector("#admin-console")).click();
+	public void changeBodyToNotRequiredOnEntryContent() {
 
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// select content types
-		siteConfigPage.selectContentTypeOption();
-
-		// open content types
-
-		siteConfigPage.clickExistingTypeOption();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// Select the Entry content type
-
-		siteConfigPage.selectEntryContentType();
-
-		// Confirm the content type selected
-
-		siteConfigPage.confirmContentTypeSelected();
+		previewPage.changeBodyOfEntryContentPageToNotRequired();
 
 	}
 
-	public void bodyNotRequired() {
-		// select main content
-
-		driverManager.getDriver().findElement(By.cssSelector("#yui-gen8")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// Body not required
-
-		driverManager.getDriver()
-				.findElement(By.cssSelector("div.property-wrapper:nth-child(21) > div:nth-child(2) > input")).click();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// save
-
-		siteConfigPage.saveDragAndDropProcess();
-	}
+//	public void bodyNotRequired() {
+//		// select main content
+//
+//		driverManager.getDriver().findElement(By.cssSelector("#yui-gen8")).click();
+//
+//		// wait for element is clickeable
+//
+//		homePage.getDriverManager().driverWait();
+//
+//		// Body not required
+//
+//		driverManager.getDriver()
+//				.findElement(By.cssSelector("div.property-wrapper:nth-child(21) > div:nth-child(2) > input")).click();
+//
+//		// wait for element is clickeable
+//
+//		homePage.getDriverManager().driverWait();
+//
+//		// save
+//
+//		siteConfigPage.saveDragAndDropProcess();
+//	}
 
 	public void createNewContent() {
 		// right click to see the the menu
@@ -243,18 +249,9 @@ public class DuplicateOptionTest {
 		// goto preview page
 
 		goToPreviewPage();
-		
+
 		// select the content type to the test
-
-		selectContentTypeToTheTest();
-
-		// wait for element is clickeable
-
-		homePage.getDriverManager().driverWait();
-
-		// Body Not requiered
-
-		bodyNotRequired();
+		changeBodyToNotRequiredOnEntryContent();
 
 		// wait for element is clickeable
 

--- a/src/test/java/org/craftercms/studio/test/pages/SiteConfigPage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/SiteConfigPage.java
@@ -25,6 +25,7 @@ public class SiteConfigPage {
 	private String displayTemplateField;
 	private String editFTLOption;
 	private String inputTitle;
+	private String inputName;
 	private String inputIceGroup;
 	private String inputDescription;
 	private String inputDefaultValue;
@@ -41,6 +42,12 @@ public class SiteConfigPage {
 	public String clickOnVideoSection;
 	public String clickOnLabelSection;
 	public String clickOnPageOrderSection;
+	public String clickOnFileNameSection;
+	public String clickOnAutoFileNameSection;
+	public String clickOnDataSourceChildContentSection;
+	public String clickOnDataSourceImageUploadedFromDesktopSection;
+	public String clickOnDataSourceImageUploadedFromRepositorySection;
+	public String clickOnDataSourceImageUploadedFromCMISRepositorySection;
 
 	/**
 	 * 
@@ -63,6 +70,7 @@ public class SiteConfigPage {
 		editFTLOption = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.edit_FTL_Option");
 		inputTitle = UIElementsPropertiesManager.getSharedUIElementsLocators().getProperty("adminconsole.input_Title");
+		inputName = UIElementsPropertiesManager.getSharedUIElementsLocators().getProperty("adminconsole.input_Name");
 		inputIceGroup = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.input_Ice_Group");
 		inputDescription = UIElementsPropertiesManager.getSharedUIElementsLocators()
@@ -95,6 +103,18 @@ public class SiteConfigPage {
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainerlabel");
 		clickOnPageOrderSection = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("adminconsole.contenttype.entry.contenttypecontainerpageorder");
+		clickOnFileNameSection = UIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerfilename");
+		clickOnAutoFileNameSection = UIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerautofilename");
+		clickOnDataSourceChildContentSection = UIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerdatasourcechildcontent");
+		clickOnDataSourceImageUploadedFromDesktopSection = UIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerdatasourceimageuploadedfromdesktop");
+		clickOnDataSourceImageUploadedFromRepositorySection = UIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerdatasourceimageuploadedfromrepository");
+		clickOnDataSourceImageUploadedFromCMISRepositorySection=UIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("adminconsole.contenttype.entry.contenttypecontainerdatasourceimageuploadedfromCMISrepository");
 	}
 
 	public SiteConfigPage(WebDriver driver) {
@@ -302,30 +322,11 @@ public class SiteConfigPage {
 		this.setDescription(strDescription);
 	}
 
-	// Complete input fields basics
-	public void completeInputFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
-	public void completeRepeatingGroupFieldsBasics(String strTitle, String strICEGroup, String strDescription) {
-
-		this.completeControlsFieldsBasics2(strTitle, strICEGroup, strDescription);
-
-	}
-
-	public void completeTextAreaFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	// Click on input section to can view the properties
-
 	public void clickOnInputSectionToViewTheProperties() {
 
-		WebElement showInputSection = driver.findElement(By.xpath(clickOnInputSection));
-		showInputSection.click();
-
+		WebElement showSection = driver.findElement(By.xpath(clickOnInputSection));
+		showSection.click();
 	}
 
 	public void clickInputSection() {
@@ -347,8 +348,8 @@ public class SiteConfigPage {
 	// Click on Repeating group to view the properties of it
 	public void clickOnRepeatingGroupToViewTheProperties() {
 
-		WebElement showRepeatingGroupSection = driver.findElement(By.xpath(clickOnRepeatingGroupSection));
-		showRepeatingGroupSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnRepeatingGroupSection));
+		showSection.click();
 
 	}
 
@@ -363,8 +364,8 @@ public class SiteConfigPage {
 	// Click on Repeating group to view the properties of it
 	public void clickOnTextAreaToViewTheProperties() {
 
-		WebElement showRepeatingGroupSection = driver.findElement(By.xpath(clickOnTextAreaSection));
-		showRepeatingGroupSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnTextAreaSection));
+		showSection.click();
 
 	}
 
@@ -393,15 +394,9 @@ public class SiteConfigPage {
 		this.selectPageArticleContentTypeOption();
 	}
 
-	public void completeRTEFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-
-	}
-
 	public void clickRTESectionToViewProperties() {
-		WebElement showRTESection = driver.findElement(By.xpath(clickOnRTESection));
-		showRTESection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnRTESection));
+		showSection.click();
 	}
 
 	public void clickRTESection() {
@@ -409,14 +404,9 @@ public class SiteConfigPage {
 
 	}
 
-	public void completeDropdonwFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	public void clickDropdownSectionToViewProperties() {
-		WebElement showDropdownSection = driver.findElement(By.xpath(clickOnDropdownSection));
-		showDropdownSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnDropdownSection));
+		showSection.click();
 	}
 
 	public void clickDropdownSection() {
@@ -424,14 +414,9 @@ public class SiteConfigPage {
 
 	}
 
-	public void completeaDateTimeFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	public void clickDateTimeSectionToViewProperties() {
-		WebElement showDateTimeSection = driver.findElement(By.xpath(clickOnDropdownSection));
-		showDateTimeSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnDropdownSection));
+		showSection.click();
 	}
 
 	public void clickDateTimeSection() {
@@ -439,14 +424,9 @@ public class SiteConfigPage {
 
 	}
 
-	public void completeaCheckBoxFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	public void clickCheckBoxSectionToViewProperties() {
-		WebElement showCheckBoxSection = driver.findElement(By.xpath(clickOnCheckBoxSection));
-		showCheckBoxSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnCheckBoxSection));
+		showSection.click();
 	}
 
 	public void clickCheckBoxSection() {
@@ -454,24 +434,14 @@ public class SiteConfigPage {
 
 	}
 
-	public void completeaGroupedCheckBoxesFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	public void clickGroupedCheckBoxesSectionToViewProperties() {
-		WebElement showGroupedCheckBoxesSection = driver.findElement(By.xpath(clickOnGroupedCheckBoxesSection));
-		showGroupedCheckBoxesSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnGroupedCheckBoxesSection));
+		showSection.click();
 	}
 
 	public void clickGroupedCheckBoxSection() {
 		this.clickGroupedCheckBoxesSectionToViewProperties();
 
-	}
-
-	public void completeItemSelectorFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
 	}
 
 	public void clickItemSelectorToViewProperties() {
@@ -484,14 +454,9 @@ public class SiteConfigPage {
 
 	}
 
-	public void completeImageFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	public void clickImageToViewProperties() {
-		WebElement showImageSection = driver.findElement(By.xpath(clickOnImageSection));
-		showImageSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnImageSection));
+		showSection.click();
 	}
 
 	public void clickImageSection() {
@@ -499,24 +464,14 @@ public class SiteConfigPage {
 
 	}
 
-	public void completeVideoFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	public void clickVideoToViewProperties() {
-		WebElement showVideoSection = driver.findElement(By.xpath(clickOnVideoSection));
-		showVideoSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnVideoSection));
+		showSection.click();
 	}
 
 	public void clickVideoSection() {
 		this.clickVideoToViewProperties();
 
-	}
-
-	public void completeLabelFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
 	}
 
 	public void clickLabelToViewProperties() {
@@ -529,18 +484,94 @@ public class SiteConfigPage {
 
 	}
 
-	public void completePageOrderFieldsBasics(String strTitle, String strICEGroup, String strDescription,
-			String strDefaultValue) {
-		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
-	}
-
 	public void clickPageOrderToViewProperties() {
-		WebElement showPageOrderSection = driver.findElement(By.xpath(clickOnPageOrderSection));
-		showPageOrderSection.click();
+		WebElement showSection = driver.findElement(By.xpath(clickOnPageOrderSection));
+		showSection.click();
 	}
 
 	public void clickPageOrderSection() {
 		this.clickPageOrderToViewProperties();
 
 	}
+
+	public void clickFileNameToViewProperties() {
+		WebElement showSection = driver.findElement(By.xpath(clickOnFileNameSection));
+		showSection.click();
+	}
+
+	public void clickFileNameSection() {
+		this.clickFileNameToViewProperties();
+
+	}
+
+	public void completeControlFieldsBasics(String strTitle, String strICEGroup, String strDescription,
+			String strDefaultValue) {
+		this.completeControlsFieldsBasics(strTitle, strICEGroup, strDescription, strDefaultValue);
+	}
+
+	public void completeControlFieldsBasics2(String strTitle, String strICEGroup, String strDescription) {
+		this.completeControlsFieldsBasics2(strTitle, strICEGroup, strDescription);
+	}
+
+	public void clickAutoFileNameToViewProperties() {
+		WebElement showSection = driver.findElement(By.xpath(clickOnAutoFileNameSection));
+		showSection.click();
+	}
+
+	public void clickAutoFileNameSection() {
+		this.clickAutoFileNameToViewProperties();
+
+	}
+
+	public void completeDataSourcesFieldsBasics(String strTitle) {
+		// Fill title
+		this.setTitle(strTitle);
+	}
+
+//	private void setName(String strName) {
+//		WebElement typeName = driver.findElement(By.cssSelector(inputName));
+//		typeName.sendKeys(strName);
+//	}
+
+	public void completeDataSourceFieldsBasics(String strTitle) {
+
+		this.completeDataSourcesFieldsBasics(strTitle);
+	}
+
+	public void clickDataSourceChildContentToViewProperties() {
+		WebElement showSection = driver.findElement(By.xpath(clickOnDataSourceChildContentSection));
+		showSection.click();
+	}
+
+	public void clickDataSourceChildContentSection() {
+		clickDataSourceChildContentToViewProperties();
+	}
+
+	public void clickDataSourceImageUploadedFromDesktopToViewProperties() {
+		WebElement showSection = driver.findElement(By.xpath(clickOnDataSourceImageUploadedFromDesktopSection));
+		showSection.click();
+	}
+
+	public void clickDataSourceImageUploadedFromDesktopSection() {
+		clickDataSourceImageUploadedFromDesktopToViewProperties();
+	}
+
+	public void clickDataSourceImageUploadedFromRepositoryToViewProperties() {
+		WebElement showSection = driver.findElement(By.xpath(clickOnDataSourceImageUploadedFromRepositorySection));
+		showSection.click();
+	}
+
+	public void clickDataSourceImageUploadedFromRepositorySection() {
+		clickDataSourceImageUploadedFromRepositoryToViewProperties();
+	}
+
+	public void clickDataSourceImageUploadedFromCMISRepositoryToViewProperties() {
+		WebElement showSection = driver.findElement(By.xpath(clickOnDataSourceImageUploadedFromCMISRepositorySection));
+		showSection.click();
+	}
+
+	public void clickDataSourceImageUploadedFromCMISRepositorySection() {
+		clickDataSourceImageUploadedFromCMISRepositoryToViewProperties();
+	}
+
 }

--- a/src/test/resources/SharedUIElements.properties
+++ b/src/test/resources/SharedUIElements.properties
@@ -55,6 +55,7 @@ adminconsole.generic_title = #content-type-canvas .content-form-name
 adminconsole.display_Template_Field = #properties-container > div > div:nth-child(6) .content-type-property-sheet-property-value
 adminconsole.edit_FTL_Option = #properties-container  > div > div:nth-child(6) .edit
 adminconsole.input_Title = #properties-container .property-input-title
+adminconsole.input_Name =#properties-container .property-input-name
 adminconsole.input_Ice_Group = #properties-container .property-wrapper:nth-child(4) input
 adminconsole.input_Description = #properties-container .property-wrapper:nth-child(5) input
 adminconsole.input_Default_Value = #properties-container .property-wrapper:nth-child(6) input
@@ -102,6 +103,25 @@ adminconsole.contenttype.entry.contenttypecontainerlabeltitle = .//div[contains(
 adminconsole.contenttype.entry.controlspageorder=.//h4[@id='control-tools-panel']/../div/div[14]
 adminconsole.contenttype.entry.contenttypecontainerpageorder=.//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Default Section Title')]/../div
 adminconsole.contenttype.entry.contenttypecontainerpageordertitle = .//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Default Section Title')]/../div/span[1]
+adminconsole.contenttype.entry.controlsfilename=.//h4[@id='control-tools-panel']/../div/div[15]
+adminconsole.contenttype.entry.contenttypecontainerfilename=.//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Default Section Title')]/../div
+adminconsole.contenttype.entry.contenttypecontainerfilenametitle = .//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Default Section Title')]/../div/span[1]
+adminconsole.contenttype.entry.controlsautofilename=.//h4[@id='control-tools-panel']/../div/div[16]
+adminconsole.contenttype.entry.contenttypecontainerautofilename=.//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Default Section Title')]/../div
+adminconsole.contenttype.entry.contenttypecontainerautofilenametitle = .//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Default Section Title')]/../div/span[1]
+adminconsole.contenttype.entry.datasourcechildcontent=.//h4[@id='datasources-tools-panel']/../div/div[1]
+adminconsole.contenttype.entry.contenttypecontainerdatasourcechildcontent=.//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]
+adminconsole.contenttype.entry.contenttypecontainerchildcontenttitle = .//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]/span[1]
+adminconsole.contenttype.entry.datasourceimageuploadedfromdesktop=.//h4[@id='datasources-tools-panel']/../div/div[2]
+adminconsole.contenttype.entry.contenttypecontainerdatasourceimageuploadedfromdesktop=.//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]
+adminconsole.contenttype.entry.contenttypecontainerimageuploadedfromdesktoptitle = .//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]/span[1]
+adminconsole.contenttype.entry.datasourceimageuploadedfromrepository=.//h4[@id='datasources-tools-panel']/../div/div[3]
+adminconsole.contenttype.entry.contenttypecontainerdatasourceimageuploadedfromrepository=.//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]
+adminconsole.contenttype.entry.contenttypecontainerimageuploadedfromrepositorytitle = .//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]/span[1]
+adminconsole.contenttype.entry.datasourceimageuploadedfromCMISrepository=.//h4[@id='datasources-tools-panel']/../div/div[4]
+adminconsole.contenttype.entry.contenttypecontainerdatasourceimageuploadedfromCMISrepository=.//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]
+adminconsole.contenttype.entry.contenttypecontainerimageuploadedfromCMISrepositorytitle = .//div[contains(@class,'content-type-visual-container')]/div/span[contains(text(),'Data Sources')]/../div[2]/span[1]
+
 
 ##My Recent Activity iframe elements
 ##Referenced by xpath selectors and id's

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -114,7 +114,8 @@
 		<classes>
 			<class
 				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
-			<class name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesDragAndDropTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesDragAndDropTest" />
 			<class
 				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
 		</classes>
@@ -438,7 +439,6 @@
 				name="org.craftercms.studio.test.cases.userspagetestcases.ChangePasswordUserTest" />
 		</classes>
 	</test> <!-- Test -->
-
 	<test name="Add New Content Section Dfaults Test">
 		<classes>
 			<class
@@ -479,6 +479,169 @@
 				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
 		</classes>
 	</test> <!-- Test -->
+	<test name="Add RTE Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddRichTextEditorTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add Dropdown Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddDropdownTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add DateTime Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddDateTimeTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add CheckBox Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddCheckBoxTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add GroupedCheckBoxes Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddGroupedCheckBoxesTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add ItemSelector Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddItemSelectorTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add Image Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddImageTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add Video Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddVideoTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add Label Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddLabelTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add PageOrder Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddPageOrderTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add FileName Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddFileNameTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add AutoFileName Control to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddAutoFileNameTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test name="Add DataSource_ChildContent to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddDataSourceChildContentTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test
+		name="Add DataSource_ImageUploadedFromDesktop to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddDataSourceImageUploadedFromDesktopTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test
+		name="Add DataSource_ImageUploadedFromRepository to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddDataSourceImageUploadedFromRepositoryTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
+	<test
+		name="Add DataSource_ImageUploadedFromCMISRepository to an existing Content Type">
+		<classes>
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteEmptyTest" />
+			<class
+				name="org.craftercms.studio.test.cases.contenttypepagetestcases.ContentTypesAddDataSourceImageUploadedFromCMISRepositoryTest" />
+			<class
+				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
+		</classes>
+	</test> <!-- Test -->
 	<test name="Create Site with WebSiteEditorial Blueprint">
 		<classes>
 			<class
@@ -487,15 +650,5 @@
 				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
 		</classes>
 	</test> <!-- Test -->
-	<test name="Crafter3LoadTest" preserve-order="true">
-		<classes>
-			<class
-				name="org.craftercms.studio.test.cases.sitespagetestcases.CreateSiteWithWebSiteEditorialBluePrintTest" />
-			<class
-				name="org.craftercms.studio.test.cases.complexscenariostestcases.Crafter3LoadTest1Script" />
 
-			<class
-				name="org.craftercms.studio.test.cases.sitespagetestcases.DeleteSiteTest" />
-		</classes>
-	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
	-ContentTypesAddAutoFileNameTest
        -ContentTypesAddDataSourceChildContentTest
        -ContentTypesAddDataSourceImageUploadedFromCMISRepositoryTest
        -ContentTypesAddDataSourceImageUploadedFromDesktopTest
        -ContentTypesAddDataSourceImageUploadedFromRepositoryTest
        -ContentTypesAddFileNameTest
-Added some improvements to use changeBodyToNotRequiredOnEntryContent where we need to set as not required the RTE field to continue testing things like for example: AddNewContentEntryTest